### PR TITLE
Fix export in md2html package

### DIFF
--- a/md2html/__init__.py
+++ b/md2html/__init__.py
@@ -1,1 +1,5 @@
-from .converter import Token
+"""Expose the public API for the md2html package."""
+
+from .converter import MarkdownConverter
+
+__all__ = ["MarkdownConverter"]


### PR DESCRIPTION
## Summary
- clean up `md2html/__init__.py`
- export `MarkdownConverter` and define `__all__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c7f5b14083309c9d21b720db8c7a