### PR TITLE
Fix image regex handling titles

### DIFF
--- a/md2html/inlineConvert.py
+++ b/md2html/inlineConvert.py
@@ -20,8 +20,17 @@ def markdown_to_html_inline(text):
     text = re.sub(r'\*([^\*]+)\*', r'<em>\1</em>', text)
     # Italic with _.
     text = re.sub(r'_([^_]+)_', r'<em>\1</em>', text)
-    # Images
-    text = re.sub(r'!\[([^\]]*)\]\(([^)]+)\)', r'<img alt="\1" src="\2">', text)
+    # Images with optional title
+    def repl_image(match):
+        alt_text = match.group(1)
+        src = match.group(2)
+        title = match.group(3)
+        if title:
+            return f'<img alt="{alt_text}" src="{src}" title="{title}">'
+        else:
+            return f'<img alt="{alt_text}" src="{src}">' 
+
+    text = re.sub(r'!\[([^\]]*)\]\(([^\s)]+)(?:\s+"([^"]+)")?\)', repl_image, text)
     # Links
     text = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', r'<a href="\2">\1</a>', text)
     return text


### PR DESCRIPTION
## Summary
- support optional image titles in inline converter regex

## Testing
- `pytest -q` *(no tests found)*
- `python md2html/run.py examples/example.md output.html`


------
https://chatgpt.com/codex/tasks/task_e_688794f570d083308a34a811cbf40f46