### PR TITLE
Fix code block conversion

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -30,5 +30,15 @@ Now a nested list:
         self.assertIn('<ul>', html)
         self.assertIn('<code>code goes here</code>', html)
 
+    def test_fenced_code_block(self):
+        markdown = """```
+<tag>This is a code block</tag>
+```
+"""
+        converter = MarkdownConverter()
+        html = converter.convert(markdown)
+        self.assertIn('<pre><code>', html)
+        self.assertIn('&lt;tag&gt;This is a code block&lt;/tag&gt;', html)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- implement code block detection for fenced and indented blocks in `MarkdownConverter`
- ensure indented list items aren't mistaken for code blocks
- add tests covering fenced code blocks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887e9a13bf48330bf3f14dc4022d4ba